### PR TITLE
docs(portfolio): sync with README — Braincrew, ACL Accepted, Snowflake 2nd Place

### DIFF
--- a/docs/cover-letter.md
+++ b/docs/cover-letter.md
@@ -20,7 +20,7 @@ Wanted Learning K-Digital Training 과정을 거치며 AI/ML의 기초부터 다
 
 #### 현재의 나에게 미친 지속적인 영향력
 
-현재 저는 (주)사운드마인드에서 AI Research Engineer로서 High-Performance RAG Engine 아키텍처를 설계하고, Enterprise RAG Agent PlayGround를 Project Lead로 이끌고 있습니다. 건설 현장에서 익힌 "복잡한 이해관계 조율"과 "프로젝트 전체 흐름 관리" 역량이 AI 시스템 설계에 그대로 적용되고 있습니다.
+(주)사운드마인드(2025.07 ~ 2026.03)에서 AI Research Engineer로서 High-Performance RAG Engine 아키텍처를 설계하고, Enterprise RAG Agent PlayGround를 Project Lead로 이끌었습니다. 이후 (주)브레인크루 Research Engineering 팀에 Engineering Part Lead로 합류해, 프로덕션 AI 시스템을 End-to-End로 만들고 있습니다. 건설 현장에서 익힌 "복잡한 이해관계 조율"과 "프로젝트 전체 흐름 관리" 역량이 AI 시스템 설계에 그대로 적용되고 있습니다.
 
 ---
 
@@ -48,7 +48,7 @@ Wanted Learning K-Digital Training 과정을 거치며 AI/ML의 기초부터 다
 
 #### 활동의 시작 동기와 목표 설정
 
-사운드마인드에서 AI Research Lead로서 마주한 첫 번째 과제는 "AI 기술을 어떻게 고객에게 증명할 것인가"였습니다. AI 기술은 추상적이어서 고객사에게 설명하기 어렵고, 제안서만으로는 기술력을 증명하기 힘들었습니다. 또한 기본적인 RAG 시스템은 검색 정확도가 낮고, LLM이 생성한 답변의 근거를 검증할 방법이 없었습니다.
+사운드마인드에서 AI Research Engineer로서 마주한 첫 번째 과제는 "AI 기술을 어떻게 고객에게 증명할 것인가"였습니다. AI 기술은 추상적이어서 고객사에게 설명하기 어렵고, 제안서만으로는 기술력을 증명하기 힘들었습니다. 또한 기본적인 RAG 시스템은 검색 정확도가 낮고, LLM이 생성한 답변의 근거를 검증할 방법이 없었습니다.
 
 #### 목표 달성을 위해 거쳐온 핵심적인 수행 과정
 
@@ -62,7 +62,7 @@ Wanted Learning K-Digital Training 과정을 거치며 AI/ML의 기초부터 다
 
 #### 결과가 가져온 변화와 개인적 보람
 
-현재 이 시스템은 B2B 영업 도구, 요구사항 수집 도구, 사내 Ideation 도구로 활용되고 있습니다. "AI 기술의 비즈니스 가치를 증명하는 도구"로서, 회사의 기술경쟁력 제고에 기여하고 있습니다. 2026년 상반기 AI Platform R&D 전략 및 로드맵 수립을 리드하며, 기술과 비즈니스를 연결하는 역할을 수행하고 있습니다.
+이 시스템은 사운드마인드 내부에서 B2B 영업 도구, 요구사항 수집 도구, 사내 Ideation 도구로 활용되었습니다. "AI 기술의 비즈니스 가치를 증명하는 도구"로서 회사의 기술경쟁력 제고에 기여했고, 2026년 상반기 AI Platform R&D 전략 및 로드맵 수립을 리드하며 기술과 비즈니스를 연결하는 역할을 수행했습니다.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -6,15 +6,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="김형섭 - AI Research Engineer Portfolio">
   <meta name="keywords" content="AI Researcher, AI Engineer, LangGraph, LangChain, RAG, Python, Machine Learning">
-  <meta name="author" content="Hyeongseob Kim">
+  <meta name="author" content="Hyeong-seob(Harrison) Kim">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Hyeongseob Kim | AI Research Engineer">
+  <meta property="og:title" content="Hyeong-seob(Harrison) Kim | AI Research Engineer">
   <meta property="og:description" content="AI Engineer Portfolio - NLP Engineer(RAG & Agent) ">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://hyeongseob91.github.io/">
 
-  <title>Hyeongseob Kim | AI Research Engineer</title>
+  <title>Hyeong-seob(Harrison) Kim | AI Research Engineer</title>
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -31,7 +31,7 @@
   <!-- Navigation -->
   <nav class="navbar" id="navbar">
     <div class="navbar__container">
-      <a href="#" class="navbar__brand">Hyeongseob Kim</a>
+      <a href="#" class="navbar__brand">Hyeong-seob(Harrison) Kim</a>
       <ul class="navbar__menu" id="navMenu">
         <li><a href="#about" class="navbar__link">About</a></li>
         <li class="navbar__dropdown">
@@ -91,19 +91,21 @@
       </div>
       <div class="about__grid">
         <div class="about__image-wrapper fade-in">
-          <img src="images/aboutme/me2.jpg" alt="Hyeongseob Kim" class="about__image">
+          <img src="images/aboutme/me2.jpg" alt="Hyeong-seob(Harrison) Kim" class="about__image">
         </div>
         <div class="about__content fade-in">
           <h3 class="hero__name">AI 시스템을 설계하고 최신 기술을 연구합니다</h3>
           <p class="about__text">
             건축공학을 전공하고 10년간 건설 현장에서 다중 이해관계자 조율과 프로젝트 관리를 수행한 경험이,<br>
-            현재 <span class="about__highlight">AI Research Engineer</span>로서 MSA 9개 프로젝트의 API 경계 설계와
-            복잡한 파이프라인 아키텍처 의사결정에 직접적으로 이어지고 있습니다.
+            <span class="about__highlight">AI Research Engineer</span>로서 MSA 9개 프로젝트의 API 경계 설계와
+            복잡한 파이프라인 아키텍처 의사결정에 직접적으로 이어졌습니다.
           </p>
           <p class="about__text">
-            <strong>SoundMind Inc.</strong>에서 RAG Pipeline 설계·최적화부터
+            <strong>SoundMind Inc.</strong> (2025.07 ~ 2026.03)에서 RAG Pipeline 설계·최적화부터
             고객이 직접 운용할 수 있는 Admin Console과 B2B SaaS Platform까지,
-            <span class="about__highlight">AI Ecosystem 전체</span>를 설계하고 구축을 주도하고 있습니다.
+            <span class="about__highlight">AI Ecosystem 전체</span>를 설계·구축을 주도했고,
+            현재는 <strong>Braincrew Research Engineering 팀</strong>에서 <span class="about__highlight">Engineering Part Lead</span>로서
+            프로덕션 AI 시스템을 End-to-End로 만들고 있습니다.
           </p>
           <p class="about__text">
             개발자 크루 <span class="about__highlight">WIGTN</span>을 리드하며
@@ -116,7 +118,7 @@
             <span class="about__highlight">WIGVO</span>는
             Dual-Session Echo Gating이라는 독자적인 아키텍처로 에코 루프를 소프트웨어만으로 제거하며,
             실제 통화 데이터로 검증하여
-            <span class="about__highlight">ACL 2026 System Demonstrations</span>에 투고하였습니다.
+            <span class="about__highlight">ACL 2026 System Demonstrations</span>에 채택되었습니다.
             <br>
             앞으로도 좋은 연구로 세상에 도움이 되는 엔지니어가 되고 싶습니다.
           </p>
@@ -134,7 +136,20 @@
       </div>
       <div class="timeline">
 
-        <!-- 사운드마인드 (2025.07 - 현재) -->
+        <!-- Braincrew (2026.04 - 현재) -->
+        <div class="timeline__item">
+          <div class="timeline__marker"></div>
+          <span class="timeline__date">2026.04 - 현재</span>
+          <h3 class="timeline__title">(주)브레인크루</h3>
+          <p class="timeline__subtitle">Research Engineering 팀 / Engineering Part Lead</p>
+          <div class="timeline__description">
+            <ul>
+              <li>Research Engineering 팀의 Engineering Part를 리드하며, 프로덕션 AI 시스템을 End-to-End로 설계·구축</li>
+            </ul>
+          </div>
+        </div>
+
+        <!-- 사운드마인드 (2025.07 - 2026.03) -->
         <div class="timeline__item">
           <div class="timeline__marker"></div>
           <span class="timeline__date">2025.07 - 2026.03</span>
@@ -156,7 +171,7 @@
             <span class="about__highlight">[AI R&D]</span>
             <ol style="margin-left: 20px;">
               <li>
-                <strong>WIGVO:</strong> 레거시 PSTN 환경 실시간 양방향 음성 번역 시스템 (<strong>ACL 2026 Submitted, 제 1저자</strong>)
+                <strong>WIGVO:</strong> 레거시 PSTN 환경 실시간 양방향 음성 번역 시스템 (<strong>ACL 2026 Accepted, 제 1저자</strong>)
                 <a href="projects/wigvo.html" target="_blank" rel="noopener noreferrer" class="timeline__project-link">
                   <i class="fa-solid fa-arrow-up-right-from-square"></i> 상세보기
                 </a>
@@ -358,6 +373,25 @@
         <p class="section__subtitle">수상 경력</p>
       </div>
       <div class="timeline">
+        <div class="timeline__item">
+          <div class="timeline__marker"></div>
+          <span class="timeline__date">2026.04</span>
+          <h3 class="timeline__title">🥈 Snowflake AI &amp; Data Hackathon 2026 Korea — Tech Track 2nd Place</h3>
+          <p class="timeline__subtitle">Team WIGTN — WIGTN FLAKE: 목적 기반 동네 인텔리전스 플랫폼</p>
+          <div class="timeline__description">
+            <p>사용자가 '하고 싶은 일'(카페 창업, 렌탈 가전 마케팅, 광고판 입지, 부동산 투자 등)을 선택하면, AI 전문가 패널이 부동산 시세·유동인구·카드매출·통신계약 4개 데이터셋을 교차 분석하여 Top 3 동네를 추천하고 이상 시그널을 자동 감지·6개월 트렌드를 예측합니다. Snowflake Cortex × GPT-4o 하이브리드 오케스트레이션.</p>
+            <p style="margin-top: 8px;">
+              <a href="https://youtu.be/1YzSp3SdzTk" target="_blank" rel="noopener noreferrer" class="timeline__project-link">
+                <i class="fa-brands fa-youtube"></i> Demo
+              </a>
+              &nbsp;·&nbsp;
+              <a href="https://www.newswire.co.kr/newsRead.php?no=1033575" target="_blank" rel="noopener noreferrer" class="timeline__project-link">
+                <i class="fa-solid fa-newspaper"></i> News
+              </a>
+            </p>
+          </div>
+        </div>
+
         <div class="timeline__item">
           <div class="timeline__marker"></div>
           <span class="timeline__date">2022.12</span>
@@ -597,13 +631,13 @@
           </div>
           <div class="project-card__content">
             <h3 class="project-card__title">
-              <span class="project-card__category-text">[ACL 2026 Submitted]</span>
+              <span class="project-card__category-text">[ACL 2026 Accepted]</span>
               <span class="project-card__title-main">
                 WIGVO - PSTN 전화망에서 에코 루프를 소프트웨어로 제거한 실시간 양방향 음성 번역
               </span>
             </h3>
             <p class="project-card__description">
-              저음역대 PSTN 전화망에서 Echo Loop를 차단할 수 있는 아키텍처 개발. 실증 테스트 0/148건 성능 확인, ACL 2026 System Demonstration 1저자 투고.
+              저음역대 PSTN 전화망에서 Echo Loop를 차단할 수 있는 아키텍처 개발. 실증 테스트 0/148건 성능 확인, ACL 2026 System Demonstration 1저자 채택.
             </p>
             <div class="project-card__tags">
               <span class="project-card__tag">OpenAI Realtime</span>
@@ -971,7 +1005,7 @@
   <footer class="footer">
     <div class="container">
       <p class="footer__text">
-        &copy; 2025 Hyeongseob Kim. Built with passion.
+        &copy; 2026 Hyeong-seob(Harrison) Kim. Built with passion.
       </p>
     </div>
   </footer>

--- a/projects/bemymuse.html
+++ b/projects/bemymuse.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BE MY MUSE - KoGPT-2 기반 감성 작사 AI | Hyeongseob Kim Portfolio</title>
+  <title>BE MY MUSE - KoGPT-2 기반 감성 작사 AI | Hyeong-seob(Harrison) Kim Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="report-header">
     <div class="report-header__inner">
-      <a href="../index.html" class="report-header__brand">Hyeongseob Kim</a>
+      <a href="../index.html" class="report-header__brand">Hyeong-seob(Harrison) Kim</a>
 
     </div>
   </header>
@@ -180,7 +180,7 @@
     <ul class="report-toc__list" id="toc-list"></ul>
   </nav>
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
   <script src="project.js"></script>
 </body>

--- a/projects/econdigest.html
+++ b/projects/econdigest.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>EconDigest - 경제 유튜브 요약 | Hyeongseob Kim Portfolio</title>
+  <title>EconDigest - 경제 유튜브 요약 | Hyeong-seob(Harrison) Kim Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="report-header">
     <div class="report-header__inner">
-      <a href="../index.html" class="report-header__brand">Hyeongseob Kim</a>
+      <a href="../index.html" class="report-header__brand">Hyeong-seob(Harrison) Kim</a>
 
     </div>
   </header>
@@ -215,7 +215,7 @@
     <ul class="report-toc__list" id="toc-list"></ul>
   </nav>
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
   <script src="project.js"></script>
 </body>

--- a/projects/komi.html
+++ b/projects/komi.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>KOMI - AI 기반 원격 재활 진료 서비스 | Hyeongseob Kim Portfolio</title>
+  <title>KOMI - AI 기반 원격 재활 진료 서비스 | Hyeong-seob(Harrison) Kim Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="report-header">
     <div class="report-header__inner">
-      <a href="../index.html" class="report-header__brand">Hyeongseob Kim</a>
+      <a href="../index.html" class="report-header__brand">Hyeong-seob(Harrison) Kim</a>
 
     </div>
   </header>
@@ -211,7 +211,7 @@
     <ul class="report-toc__list" id="toc-list"></ul>
   </nav>
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
   <script src="project.js"></script>
 </body>

--- a/projects/llm-loadtester.html
+++ b/projects/llm-loadtester.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Engineering LLM Loadtester — 비개발직군용 LLM 서빙 벤치마킹 도구 | Hyeongseob Kim Portfolio</title>
+  <title>Engineering LLM Loadtester — 비개발직군용 LLM 서빙 벤치마킹 도구 | Hyeong-seob(Harrison) Kim Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="report-header">
     <div class="report-header__inner">
-      <a href="../index.html" class="report-header__brand">Hyeongseob Kim</a>
+      <a href="../index.html" class="report-header__brand">Hyeong-seob(Harrison) Kim</a>
 
     </div>
   </header>
@@ -166,7 +166,7 @@
   </nav>
 
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
 
   <script src="project.js"></script>

--- a/projects/mcp.html
+++ b/projects/mcp.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>VALORITHM - MCP 기반 게임 개발 AI 시스템 | Hyeongseob Kim Portfolio</title>
+  <title>VALORITHM - MCP 기반 게임 개발 AI 시스템 | Hyeong-seob(Harrison) Kim Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="report-header">
     <div class="report-header__inner">
-      <a href="../index.html" class="report-header__brand">Hyeongseob Kim</a>
+      <a href="../index.html" class="report-header__brand">Hyeong-seob(Harrison) Kim</a>
 
     </div>
   </header>
@@ -187,7 +187,7 @@
     <ul class="report-toc__list" id="toc-list"></ul>
   </nav>
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
   <script src="project.js"></script>
 </body>

--- a/projects/perfectpose.html
+++ b/projects/perfectpose.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>PerfectPoses - AI 자세 인식 자세 추론 게임 | Hyeongseob Kim Portfolio</title>
+  <title>PerfectPoses - AI 자세 인식 자세 추론 게임 | Hyeong-seob(Harrison) Kim Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="report-header">
     <div class="report-header__inner">
-      <a href="../index.html" class="report-header__brand">Hyeongseob Kim</a>
+      <a href="../index.html" class="report-header__brand">Hyeong-seob(Harrison) Kim</a>
 
     </div>
   </header>
@@ -164,7 +164,7 @@
     <ul class="report-toc__list" id="toc-list"></ul>
   </nav>
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
   <script src="project.js"></script>
 </body>

--- a/projects/soundmind-ecosystem.html
+++ b/projects/soundmind-ecosystem.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SoundMind AI Ecosystem | Hyeongseob Kim Portfolio</title>
+  <title>SoundMind AI Ecosystem | Hyeong-seob(Harrison) Kim Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="report-header">
     <div class="report-header__inner">
-      <a href="../index.html" class="report-header__brand">Hyeongseob Kim</a>
+      <a href="../index.html" class="report-header__brand">Hyeong-seob(Harrison) Kim</a>
 
     </div>
   </header>
@@ -107,7 +107,7 @@
         <!-- System Architecture -->
         <!-- ============================== -->
         <h2 id="system-architecture">System Architecture</h2>
-        <p>본 프로젝트는 <strong>단독 개발 프로젝트</strong>로서, 기획부터 디자인, 시스템 개발 및 배포까지 솔로프리너로 진행했습니다. 현재 Beta 버전으로 End User 테스트를 진행 중입니다.<br><br>SoundMind AI Ecosystem은 크게 <strong>3개 축</strong>으로 구성됩니다. 고객 대면 서비스(<strong>AI Platform</strong>), 내부 운영 도구(<strong>AI Console</strong> — Analysis · Eval · Monitoring), 그리고 이들이 공유하는 <strong>모델 서빙 인프라</strong>입니다.<br><br><strong>모델 서빙 인프라:</strong><br>• <strong>LLM</strong> — Qwen3 시리즈, vLLM 서빙 (OpenAI 호환 API)<br>• <strong>Embedder / Reranker</strong> — BGE-M3 + BGE-Reranker-v2-M3, Infinity 서빙. vLLM에서 BGE-M3 로드 시 아키텍처 호환 문제(XLMRobertaModel로 인식되어 sparse/colbert weight 누락)가 발생하여, 임베딩 모델 서빙에 특화된 Infinity로 전환<br><br><strong>이 글의 구성:</strong><br>① <strong>RAG R&D</strong> — Advanced RAG 구축 → 정량 평가 → Ablation Study → "문서마다 다른 전략이 필요하다"는 인사이트 도출<br>② <strong>AI Console</strong> — R&D 인사이트를 바탕으로 구축한 내부 운영 플랫폼 (Analysis · Eval · Monitoring)<br>③ <strong>AI Platform</strong> — 고객이 즉시 PoC를 체험할 수 있는 Playground (RAG Agent · Chat Agent · AICC Agent)</p>
+        <p><em>※ 2026.03 사운드마인드 퇴사 시점 기준 정리. 이후 본인의 추가 기여는 없음.</em><br><br>본 프로젝트는 <strong>단독 개발 프로젝트</strong>로서, 기획부터 디자인, 시스템 개발 및 배포까지 솔로프리너로 진행했습니다. 퇴사 시점 기준 Beta 버전으로 End User 테스트를 진행 중이었습니다.<br><br>SoundMind AI Ecosystem은 크게 <strong>3개 축</strong>으로 구성됩니다. 고객 대면 서비스(<strong>AI Platform</strong>), 내부 운영 도구(<strong>AI Console</strong> — Analysis · Eval · Monitoring), 그리고 이들이 공유하는 <strong>모델 서빙 인프라</strong>입니다.<br><br><strong>모델 서빙 인프라:</strong><br>• <strong>LLM</strong> — Qwen3 시리즈, vLLM 서빙 (OpenAI 호환 API)<br>• <strong>Embedder / Reranker</strong> — BGE-M3 + BGE-Reranker-v2-M3, Infinity 서빙. vLLM에서 BGE-M3 로드 시 아키텍처 호환 문제(XLMRobertaModel로 인식되어 sparse/colbert weight 누락)가 발생하여, 임베딩 모델 서빙에 특화된 Infinity로 전환<br><br><strong>이 글의 구성:</strong><br>① <strong>RAG R&D</strong> — Advanced RAG 구축 → 정량 평가 → Ablation Study → "문서마다 다른 전략이 필요하다"는 인사이트 도출<br>② <strong>AI Console</strong> — R&D 인사이트를 바탕으로 구축한 내부 운영 플랫폼 (Analysis · Eval · Monitoring)<br>③ <strong>AI Platform</strong> — 고객이 즉시 PoC를 체험할 수 있는 Playground (RAG Agent · Chat Agent · AICC Agent)</p>
         <figure>
           <img src="../images/projects/soundmind-ai-ecosystem-architecture.png" alt="SoundMind AI Ecosystem Architecture" onclick="window.open(this.src, '_blank')">
           <figcaption>AI Platform(고객 대면) ↔ AI Console(Analysis · Eval · Monitoring) + Cloud Server · Local Database · Local Model Serving</figcaption>
@@ -518,19 +518,19 @@
           </div>
         </div>
 
-        <h3 id="aicc-agent">③ AICC Agent — AI 컨택센터 (개발 예정)</h3>
-        <p>RAG Agent의 문서 기반 응답 능력과 Chat Agent의 자율 도구 사용 능력을 결합하여, 고객 상담 시나리오에 특화된 AI 컨택센터 에이전트입니다. 개발 예정.</p>
+        <h3 id="aicc-agent">③ AICC Agent — AI 컨택센터 (퇴사 시점 미착수)</h3>
+        <p>RAG Agent의 문서 기반 응답 능력과 Chat Agent의 자율 도구 사용 능력을 결합하여, 고객 상담 시나리오에 특화된 AI 컨택센터 에이전트로 기획되어 있었으나, 본인 퇴사(2026.03) 전까지 본격 개발에는 착수하지 못했습니다.</p>
 
         <!-- ============================== -->
         <!-- Next Step -->
         <!-- ============================== -->
-        <h2 id="next-step">Next Step</h2>
-        <p>현재 Beta 테스트를 진행 중이며, End User 피드백을 반영한 정식 배포를 준비하고 있습니다.</p>
+        <h2 id="next-step">Next Step (퇴사 시점 로드맵)</h2>
+        <p>본인 퇴사(2026.03) 시점 기준의 향후 계획입니다. 이후 진행 상황은 사운드마인드 내부에서 별도 진행되었습니다.</p>
 
         <h3 id="wigtn-ocr-integration">WigtnOCR 연동 — VLM 기반 문서 파싱 고도화</h3>
-        <p>현재 텍스트 추출 중심의 파싱을 <strong>VLM(Vision-Language Model) 기반으로 확장</strong>하여, 표·차트·레이아웃 등 시각적 구조까지 보존합니다. 별도 연구 프로젝트로 진행 중인 <strong>WigtnOCR</strong>(Qwen3-VL-2B LoRA fine-tuning → 비교 실험 4개 모델 중 Table TEDS 1위, 15배 큰 30B 모델 성능 초과)의 성과를 Ecosystem에 직접 적용하여, A/B 테스트에서 확인된 VLM 파싱의 품질 우위(0.888 → 1.000)를 전체 파이프라인에 확대할 예정입니다.</p>
+        <p>텍스트 추출 중심의 파싱을 <strong>VLM(Vision-Language Model) 기반으로 확장</strong>하여, 표·차트·레이아웃 등 시각적 구조까지 보존하는 방향으로 확장하는 것이 목표였습니다. 별도 연구 프로젝트로 진행한 <strong>WigtnOCR</strong>(Qwen3-VL-2B LoRA fine-tuning → 비교 실험 4개 모델 중 Table TEDS 1위, 15배 큰 30B 모델 성능 초과)의 성과를 Ecosystem에 직접 적용하여, A/B 테스트에서 확인된 VLM 파싱의 품질 우위(0.888 → 1.000)를 전체 파이프라인에 확대하려는 계획이 있었습니다.</p>
 
-        <h3 id="production-release">정식 배포</h3>
+        <h3 id="production-release">정식 배포 (계획)</h3>
         <ul>
           <li>Beta 테스트 피드백 기반 UX 개선 및 안정성 확보</li>
           <li>평가 → 분석 → 재배포 Feedback Loop으로 자동 최적화 사이클 구축</li>
@@ -547,7 +547,7 @@
   </nav>
 
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
 
   <script src="project.js"></script>

--- a/projects/timelens.html
+++ b/projects/timelens.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>TimeLens - 음성+카메라 멀티모달 AI 박물관 큐레이터 | Hyeongseob Kim Portfolio</title>
+  <title>TimeLens - 음성+카메라 멀티모달 AI 박물관 큐레이터 | Hyeong-seob(Harrison) Kim Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="report-header">
     <div class="report-header__inner">
-      <a href="../index.html" class="report-header__brand">Hyeongseob Kim</a>
+      <a href="../index.html" class="report-header__brand">Hyeong-seob(Harrison) Kim</a>
 
     </div>
   </header>
@@ -251,7 +251,7 @@
   </nav>
 
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
 
   <script src="project.js"></script>

--- a/projects/wigtn-coding.html
+++ b/projects/wigtn-coding.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>WIGTN-Coding — Claude Code 통합 개발 워크플로우 플러그인 | Hyeongseob Kim Portfolio</title>
+  <title>WIGTN-Coding — Claude Code 통합 개발 워크플로우 플러그인 | Hyeong-seob(Harrison) Kim Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="report-header">
     <div class="report-header__inner">
-      <a href="../index.html" class="report-header__brand">Hyeongseob Kim</a>
+      <a href="../index.html" class="report-header__brand">Hyeong-seob(Harrison) Kim</a>
 
     </div>
   </header>
@@ -137,7 +137,7 @@
         <h2 id="real-world-results">실전 결과물 — 이 플러그인으로 만든 프로젝트들</h2>
         <ul>
           <li><strong>WIGVU</strong> — 외국인을 위한 한국어 스터디 앱 (Next.js 16 + NestJS 10 + FastAPI MSA, App 배포 목표)</li>
-          <li><strong>WIGVO</strong> — PSTN 실시간 양방향 음성 번역 시스템 (ACL 2026 Submitted)</li>
+          <li><strong>WIGVO</strong> — PSTN 실시간 양방향 음성 번역 시스템 (ACL 2026 Accepted)</li>
           <li><strong>TimeLens</strong> — Gemini Live Agent Challenge 출품작 (Google Global 해커톤)</li>
           <li><strong>WIGTN-SPEAR</strong> — AI 서비스 특화 보안 스캐너 (OWASP LLM Top 10 + Web Top 10)</li>
           <li><strong>LLM Loadtester</strong> — 비개발직군용 LLM 서빙 벤치마킹 도구 (오픈소스)</li>
@@ -153,7 +153,7 @@
   </nav>
 
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
 
   <script src="project.js"></script>

--- a/projects/wigtn-ocr.html
+++ b/projects/wigtn-ocr.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>WigtnOCR - VLM 기반 한국 공공기관 문서 전용 파싱 모델 | Hyeongseob Kim Portfolio</title>
+  <title>WigtnOCR - VLM 기반 한국 공공기관 문서 전용 파싱 모델 | Hyeong-seob(Harrison) Kim Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="report-header">
     <div class="report-header__inner">
-      <a href="../index.html" class="report-header__brand">Hyeongseob Kim</a>
+      <a href="../index.html" class="report-header__brand">Hyeong-seob(Harrison) Kim</a>
 
     </div>
   </header>
@@ -305,7 +305,7 @@
     <ul class="report-toc__list" id="toc-list"></ul>
   </nav>
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
   <script src="project.js"></script>
 </body>

--- a/projects/wigvo.html
+++ b/projects/wigvo.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>WIGVO - PSTN 기반 AI 실시간 양방향 전화 통역 중계 플랫폼 | Hyeongseob Kim Portfolio</title>
+  <title>WIGVO - PSTN 기반 AI 실시간 양방향 전화 통역 중계 플랫폼 | Hyeong-seob(Harrison) Kim Portfolio</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -15,7 +15,7 @@
 <body>
   <header class="report-header">
     <div class="report-header__inner">
-      <a href="../index.html" class="report-header__brand">Hyeongseob Kim</a>
+      <a href="../index.html" class="report-header__brand">Hyeong-seob(Harrison) Kim</a>
 
     </div>
   </header>
@@ -73,7 +73,7 @@
             <li>Whisper 할루시네이션 유입률 — <strong>0.3% 미만</strong>, 통화당 평균 0.7건 차단</li>
             <li>Dual-Session Echo Gating 아키텍처 — 에코 감지·차단을 <strong>소프트웨어로 자체 설계</strong></li>
             <li>3-Stage 오디오 필터 파이프라인 — Echo Gate → Energy Gate → Silero VAD <strong>직접 설계·구현</strong></li>
-            <li>ACL 2026 System Demonstrations — <strong>Submitted, 제 1저자</strong></li>
+            <li>ACL 2026 System Demonstrations — <strong>Accepted, 제 1저자</strong></li>
           </ul>
         </div>
 
@@ -312,7 +312,7 @@
     <ul class="report-toc__list" id="toc-list"></ul>
   </nav>
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
   <script src="project.js"></script>
 </body>

--- a/wigtn/index.html
+++ b/wigtn/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Activities - 세미나, 스터디, 크루 활동 등 경험과 배움의 기록">
-  <meta name="author" content="Hyeongseob Kim">
+  <meta name="author" content="Hyeong-seob(Harrison) Kim">
 
   <title>Activities | Hyeongseob's Note</title>
 
@@ -43,7 +43,7 @@
   </main>
 
   <footer class="report-footer">
-    <p class="report-footer__copy">&copy; 2025 Hyeongseob Kim</p>
+    <p class="report-footer__copy">&copy; 2026 Hyeong-seob(Harrison) Kim</p>
   </footer>
 </body>
 


### PR DESCRIPTION
## Summary

GitHub 프로필 README의 최근 업데이트(Braincrew 합류, ACL 2026 채택, Snowflake 해커톤 2등) 내용을 포트폴리오 사이트에 동기화합니다.

### Hero / Meta / Footer
- 이름 표기 통일: `Hyeongseob Kim` → `Hyeong-seob(Harrison) Kim` (메타·navbar·alt·푸터)
- 푸터 연도 갱신: `© 2025` → `© 2026` (13곳)
- Hero H1 `KIM HYEONGSEOB`은 디자인 일관성 위해 유지

### About / Experience
- About: Soundmind 과거형(2025.07~2026.03) + Braincrew Engineering Part Lead 현재 추가
- Experience 타임라인: Braincrew (2026.04~) 항목 최상단 신설, Soundmind 종료일 반영

### Awards
- 🥈 Snowflake AI & Data Hackathon 2026 Korea — Tech Track 2nd Place 추가
  - Team WIGTN — WIGTN FLAKE: 목적 기반 동네 인텔리전스 플랫폼
  - Demo: https://youtu.be/1YzSp3SdzTk
  - News: https://www.newswire.co.kr/newsRead.php?no=1033575

### WIGVO 논문 상태
- `ACL 2026 Submitted` / `투고` → `ACL 2026 Accepted` / `채택` (index, wigvo.html, wigtn-coding.html)

### Retrospective Tone
- `projects/soundmind-ecosystem.html`: 퇴사(2026.03) 시점 기준 안내문 + Beta/AICC/Next Step 표현 과거형
- `docs/cover-letter.md`: 사운드마인드 현재형 → 과거형, Braincrew 합류 문장 추가, "AI Research Lead" 호칭 정정

## Test plan
- [ ] `index.html` 로컬 미리보기로 Hero/About/Experience/Awards 시각 점검
- [ ] 모든 프로젝트 상세 페이지 헤더 brand·푸터 연도 확인
- [ ] Snowflake Demo / News 링크 클릭 동작 확인
- [ ] `grep -rn "Submitted\|© 2025\|2025.07 - 현재"` 잔존 문구 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)