### PR TITLE
docs(portfolio): generalize About, split WIGTN as separate experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,11 +101,10 @@
             복잡한 파이프라인 아키텍처 의사결정에 직접적으로 이어졌습니다.
           </p>
           <p class="about__text">
-            <strong>SoundMind Inc.</strong> (2025.07 ~ 2026.03)에서 RAG Pipeline 설계·최적화부터
-            고객이 직접 운용할 수 있는 Admin Console과 B2B SaaS Platform까지,
-            <span class="about__highlight">AI Ecosystem 전체</span>를 설계·구축을 주도했고,
-            현재는 <strong>Braincrew Research Engineering 팀</strong>에서 <span class="about__highlight">Engineering Part Lead</span>로서
-            프로덕션 AI 시스템을 End-to-End로 만들고 있습니다.
+            현재 <strong>Braincrew Research Engineering 팀</strong>에서 <span class="about__highlight">Engineering Part Lead</span>로서
+            프로덕션 AI 시스템을 End-to-End로 설계·구축하고 있습니다.
+            지금까지 <span class="about__highlight">AI Ecosystem</span> 설계·구축, <span class="about__highlight">Advanced RAG Pipeline</span>,
+            Admin Console, B2B SaaS Platform 등을 만들어 왔습니다.
           </p>
           <p class="about__text">
             개발자 크루 <span class="about__highlight">WIGTN</span>을 리드하며
@@ -149,25 +148,13 @@
           </div>
         </div>
 
-        <!-- 사운드마인드 (2025.07 - 2026.03) -->
+        <!-- WIGTN (2026.01 - 현재) -->
         <div class="timeline__item">
           <div class="timeline__marker"></div>
-          <span class="timeline__date">2025.07 - 2026.03</span>
-          <h3 class="timeline__title">(주)사운드마인드</h3>
-          <p class="timeline__subtitle">AX 사업본부 / AI Research Engineer</p>
+          <span class="timeline__date">2026.01 - 현재</span>
+          <h3 class="timeline__title">WIGTN</h3>
+          <p class="timeline__subtitle">Founder &amp; Lead</p>
           <div class="timeline__description">
-            <span class="about__highlight">[AI Product Engineering & R&D]</span>
-            <br><strong>SoundMind AI Ecosystem</strong>
-            <a href="projects/soundmind-ecosystem.html" target="_blank" rel="noopener noreferrer" class="timeline__project-link">
-              <i class="fa-solid fa-arrow-up-right-from-square"></i> 상세보기
-            </a>
-            <ul>
-              <li>고객 문서 기반 맞춤형 RAG Pipeline 자동 생성·배포 플랫폼 (AI Console + AI Platform) 단독 설계 및 E2E 개발</li>
-              <li>2개 LLM이 문서를 교차 분석하여 최적 RAG 전략을 자동 추천하고, <strong>원클릭 Docker 배포 — 신규 엔진 배포 리드타임 2주 → 5분</strong></li>
-              <li>공공기관 전용 RAG R&D: <strong>RAGAS 기반의 LLM-as-a-Judge 평가 시스템 구축</strong>(81개 Q&A · 3,678페이지), 파이프라인 각 단계를 하나씩 제거하며 <strong>성능 기여도를 정량화</strong></li>
-              <li>MSA 9 Projects · 161 APIs · 15+ Docker · 최대 99개 Pipeline 동시 운용 · Grafana+Loki 모니터링</li>
-            </ul>
-
             <span class="about__highlight">[AI R&D]</span>
             <ol style="margin-left: 20px;">
               <li>
@@ -193,6 +180,15 @@
               </li>
             </ol>
 
+            <span class="about__highlight">[Hackathon]</span>
+            <ol style="margin-left: 20px;">
+              <li>🥈 <strong>Snowflake AI &amp; Data Hackathon 2026 Korea — Tech Track 2nd Place</strong> (Team WIGTN)
+                <ul>
+                  <li><strong>WIGTN FLAKE</strong> — 목적 기반 동네 인텔리전스 플랫폼. Snowflake Cortex × GPT-4o 하이브리드 오케스트레이션</li>
+                </ul>
+              </li>
+            </ol>
+
             <span class="about__highlight">[Open Source]</span>
             <ol style="margin-left: 20px;">
               <li><strong>WIGTN-Coding:</strong> Claude Code 기반 AI-Native 개발 워크플로우 플러그인 (7 Commands, 14 Agents, 7 Skills)
@@ -205,6 +201,27 @@
                 <a href="projects/timelens.html" target="_blank" rel="noopener noreferrer" class="timeline__project-link"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>
               </li>
             </ol>
+          </div>
+        </div>
+
+        <!-- 사운드마인드 (2025.07 - 2026.03) -->
+        <div class="timeline__item">
+          <div class="timeline__marker"></div>
+          <span class="timeline__date">2025.07 - 2026.03</span>
+          <h3 class="timeline__title">(주)사운드마인드</h3>
+          <p class="timeline__subtitle">AX 사업본부 / AI Research Engineer</p>
+          <div class="timeline__description">
+            <span class="about__highlight">[AI Product Engineering & R&D]</span>
+            <br><strong>SoundMind AI Ecosystem</strong>
+            <a href="projects/soundmind-ecosystem.html" target="_blank" rel="noopener noreferrer" class="timeline__project-link">
+              <i class="fa-solid fa-arrow-up-right-from-square"></i> 상세보기
+            </a>
+            <ul>
+              <li>고객 문서 기반 맞춤형 RAG Pipeline 자동 생성·배포 플랫폼 (AI Console + AI Platform) 단독 설계 및 E2E 개발</li>
+              <li>2개 LLM이 문서를 교차 분석하여 최적 RAG 전략을 자동 추천하고, <strong>원클릭 Docker 배포 — 신규 엔진 배포 리드타임 2주 → 5분</strong></li>
+              <li>공공기관 전용 RAG R&D: <strong>RAGAS 기반의 LLM-as-a-Judge 평가 시스템 구축</strong>(81개 Q&A · 3,678페이지), 파이프라인 각 단계를 하나씩 제거하며 <strong>성능 기여도를 정량화</strong></li>
+              <li>MSA 9 Projects · 161 APIs · 15+ Docker · 최대 99개 Pipeline 동시 운용 · Grafana+Loki 모니터링</li>
+            </ul>
           </div>
         </div>
 


### PR DESCRIPTION
- About: drop Soundmind-specific narrative; describe current Braincrew role and lifetime contributions (AI Ecosystem, Advanced RAG Pipeline, Admin Console, B2B SaaS)
- Experience: add WIGTN entry (2026.01 ~) below Braincrew, hosting WIGVO, WigtnOCR, Snowflake 2nd Place hackathon, and open-source projects (WIGTN-Coding / LLM Loadtester / TimeLens)
- Soundmind entry now scoped to SoundMind AI Ecosystem only