### PR TITLE
docs(portfolio): rewrite About + add Snowflake Demo/News links

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,6 +183,12 @@
             <span class="about__highlight">[Hackathon]</span>
             <ol style="margin-left: 20px;">
               <li>🥈 <strong>Snowflake AI &amp; Data Hackathon 2026 Korea — Tech Track 2nd Place</strong> (Team WIGTN)
+                <a href="https://youtu.be/1YzSp3SdzTk" target="_blank" rel="noopener noreferrer" class="timeline__project-link">
+                  <i class="fa-brands fa-youtube"></i> Demo
+                </a>
+                <a href="https://www.newswire.co.kr/newsRead.php?no=1033575" target="_blank" rel="noopener noreferrer" class="timeline__project-link">
+                  <i class="fa-solid fa-newspaper"></i> News
+                </a>
                 <ul>
                   <li><strong>WIGTN FLAKE</strong> — 목적 기반 동네 인텔리전스 플랫폼. Snowflake Cortex × GPT-4o 하이브리드 오케스트레이션</li>
                 </ul>

--- a/index.html
+++ b/index.html
@@ -96,30 +96,21 @@
         <div class="about__content fade-in">
           <h3 class="hero__name">AI 시스템을 설계하고 최신 기술을 연구합니다</h3>
           <p class="about__text">
-            건축공학을 전공하고 10년간 건설 현장에서 다중 이해관계자 조율과 프로젝트 관리를 수행한 경험이,<br>
-            <span class="about__highlight">AI Research Engineer</span>로서 MSA 9개 프로젝트의 API 경계 설계와
-            복잡한 파이프라인 아키텍처 의사결정에 직접적으로 이어졌습니다.
+            건축공학 전공 후 10년간 건설 현장에서 다중 이해관계자 조율과 프로젝트 관리를 수행한 경험은,
+            <span class="about__highlight">AI Research Engineer</span>로서 MSA 경계 설계와 복잡한 파이프라인 아키텍처 의사결정에 그대로 이어졌습니다.
           </p>
           <p class="about__text">
-            현재 <strong>Braincrew Research Engineering 팀</strong>에서 <span class="about__highlight">Engineering Part Lead</span>로서
-            프로덕션 AI 시스템을 End-to-End로 설계·구축하고 있습니다.
-            지금까지 <span class="about__highlight">AI Ecosystem</span> 설계·구축, <span class="about__highlight">Advanced RAG Pipeline</span>,
-            Admin Console, B2B SaaS Platform 등을 만들어 왔습니다.
+            현재 <strong>BrainCrew Research Engineering 팀</strong> <span class="about__highlight">Engineering Part Lead</span>로 합류했으며,
+            이전 직장에서는 <span class="about__highlight">Advanced RAG Pipeline</span>, Admin Console, B2B SaaS Platform 등
+            AI 시스템 5개를 9개월간 솔로로 설계·구축했습니다.
           </p>
           <p class="about__text">
             개발자 크루 <span class="about__highlight">WIGTN</span>을 리드하며
-            AI-Native 개발 도구(<span class="about__highlight">WIGTN-Coding</span>)를 오픈소스로 공개하고,
-            VLM 기반 한국 공공문서 파싱 모델(<span class="about__highlight">WigtnOCR</span>)을 HuggingFace에 오픈소스로 배포하며,
-            커뮤니티에 기여하고 있습니다.
-          </p>
-          <p class="about__text">
-            PSTN 저음역 대역폭(G.711 μ-law 8kHz)에서 실시간 양방향 음성 번역을 구현한
-            <span class="about__highlight">WIGVO</span>는
-            Dual-Session Echo Gating이라는 독자적인 아키텍처로 에코 루프를 소프트웨어만으로 제거하며,
-            실제 통화 데이터로 검증하여
+            AI-Native 개발 도구 <span class="about__highlight">WIGTN-Coding</span>과
+            VLM 기반 한국 공공문서 파싱 모델 <span class="about__highlight">WigtnOCR</span>을 오픈소스로 공개했습니다.
+            PSTN 환경(G.711 μ-law 8kHz)에서 실시간 양방향 음성 번역을 구현한 <span class="about__highlight">WIGVO</span>는
+            독자 아키텍처 Dual-Session Echo Gating으로 에코 루프를 소프트웨어만으로 제거하여
             <span class="about__highlight">ACL 2026 System Demonstrations</span>에 채택되었습니다.
-            <br>
-            앞으로도 좋은 연구로 세상에 도움이 되는 엔지니어가 되고 싶습니다.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

PR #2/#3 머지 이후 추가된 두 개의 docs 변경사항을 main에 반영합니다.

### 1. About 본문 재작성 (`b1dfe90`)
사용자가 지정한 3단락 구성으로 About 섹션을 정리:
- ¶1: 건축공학 → AI Research Engineer 전환 (MSA 경계 설계, 파이프라인 아키텍처)
- ¶2: 현재 BrainCrew Engineering Part Lead + 이전 직장에서 9개월 솔로로 AI 시스템 5개 설계·구축
- ¶3: WIGTN 리드 (WIGTN-Coding, WigtnOCR 오픈소스) + WIGVO ACL 2026 채택

### 2. Hackathon Demo/News 링크 (`68f24c9`)
WIGTN FLAKE는 별도 프로젝트 페이지가 없어, Experience 타임라인의 Snowflake 해커톤 항목 옆에 YouTube Demo + Newswire 기사 링크를 인라인으로 추가.

## Test plan
- [ ] About 3단락 렌더링 확인 (about__highlight 강조 키워드)
- [ ] Experience > WIGTN > [Hackathon] 항목의 Demo/News 링크 클릭 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)