### PR TITLE
docs(portfolio): rename Crew filter to Hackathon and add WIGTN FLAKE card

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@
         <button class="projects__filter-btn" data-filter="product">Product</button>
         <button class="projects__filter-btn" data-filter="research">Research</button>
         <button class="projects__filter-btn" data-filter="opensource">Open Source</button>
-        <button class="projects__filter-btn" data-filter="crew">WIGTN Crew</button>
+        <button class="projects__filter-btn" data-filter="hackathon">Hackathon</button>
       </div>
 
       <div class="projects__grid">
@@ -734,8 +734,44 @@
           </div>
         </article>
 
+        <!-- Project: WIGTN FLAKE -->
+        <article class="project-card fade-in" data-category="hackathon">
+          <div class="project-card__image-wrapper">
+            <img src="images/projects/wigtn_logo.png" alt="WIGTN FLAKE - Snowflake Hackathon 2nd Place" class="project-card__image">
+          </div>
+          <div class="project-card__content">
+            <h3 class="project-card__title">
+              <span class="project-card__category-text">[Snowflake Hackathon 2026 — Tech Track 🥈 2nd Place]</span>
+              <span class="project-card__title-main">
+                WIGTN FLAKE - 목적 기반 동네 인텔리전스 플랫폼
+              </span>
+            </h3>
+            <p class="project-card__description">
+              사용자가 '하고 싶은 일'(카페 창업, 렌탈 가전 마케팅, 광고판 입지, 부동산 투자 등)을 선택하면, AI 전문가 패널이 부동산 시세·유동인구·카드매출·통신계약 4개 데이터셋을 교차 분석해 Top 3 동네 추천, 이상 시그널 자동 감지, 6개월 트렌드 예측을 수행. Snowflake Cortex × GPT-4o 하이브리드 오케스트레이션으로 Team WIGTN 4인 합작.
+            </p>
+            <div class="project-card__tags">
+              <span class="project-card__tag">Snowflake Cortex</span>
+              <span class="project-card__tag">GPT-4o</span>
+              <span class="project-card__tag">Next.js</span>
+              <span class="project-card__tag">Hybrid Orchestration</span>
+            </div>
+          </div>
+          <div class="project-card__footer">
+            <a href="https://youtu.be/1YzSp3SdzTk" target="_blank" rel="noopener noreferrer"
+              class="project-card__link-btn" onclick="event.stopPropagation()">
+              <i class="fa-brands fa-youtube"></i>
+              YouTube
+            </a>
+            <a href="https://www.newswire.co.kr/newsRead.php?no=1033575" target="_blank" rel="noopener noreferrer"
+              class="project-card__link-btn" onclick="event.stopPropagation()">
+              <i class="fa-solid fa-newspaper"></i>
+              News
+            </a>
+          </div>
+        </article>
+
         <!-- Project: TimeLens -->
-        <article class="project-card fade-in" data-project="timelens" data-category="crew">
+        <article class="project-card fade-in" data-project="timelens" data-category="hackathon">
           <div class="project-card__image-wrapper">
             <img src="images/projects/timelens_logo.png" alt="TimeLens - AI Museum Curator" class="project-card__image">
           </div>


### PR DESCRIPTION
## Summary

Projects 섹션 개편:

- 필터 버튼 \`WIGTN Crew\` → \`Hackathon\` (data-filter "crew" → "hackathon")
- TimeLens(Gemini Live Agent Challenge)도 hackathon 카테고리로 재분류
- **WIGTN FLAKE 신규 프로젝트 카드 추가** (Snowflake AI & Data Hackathon 2026 — Tech Track 🥈 2nd Place)
  - YouTube Demo + Newswire News 링크
  - 이미지: \`wigtn_logo.png\` placeholder
  - 별도 detail 페이지가 없어 \`data-project\` 미지정 (카드 본문 클릭 시 404 방지)

## Test plan
- [ ] Projects 필터 탭에 \`Hackathon\` 노출 확인
- [ ] \`Hackathon\` 필터 클릭 시 WIGTN FLAKE + TimeLens 카드만 표시
- [ ] WIGTN FLAKE 카드 YouTube/News 링크 동작
- [ ] WIGTN FLAKE 카드 본문 클릭 시 404로 가지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)